### PR TITLE
Fix deprecated callback

### DIFF
--- a/src/worker.cc
+++ b/src/worker.cc
@@ -41,5 +41,6 @@ void CheckSpellingWorker::HandleOKCallback() {
   }
 
   Local<Value> argv[] = { Nan::Null(), result };
-  callback->Call(2, argv);
+  Nan::AsyncResource resource("CheckSpellingWorker::HandleOKCallback");
+  callback->Call(2, argv, &resource);
 }


### PR DESCRIPTION
To quote @abetomo:
> The following warning.
>
> ```
> ../src/worker.cc: In member function ‘virtual void
> CheckSpellingWorker::HandleOKCallback()’:
> ../src/worker.cc:44:25: warning: ‘v8::Local<v8::Value>
> Nan::Callback::Call(int, v8::Local<v8::Value>*) const’ is deprecated
> [-Wdeprecated-declarations]
>    callback->Call(2, argv);
> ```

Thank you @abetomo!